### PR TITLE
fix: remove ROLES redundancy

### DIFF
--- a/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
@@ -16,15 +16,6 @@ class RoleCommand @Inject constructor(
     aliases = arrayOf()
 ) {
 
-    companion object {
-        val ROLES: Set<Long> = setOf(
-            837576267922538516L,
-            837576282454622218L,
-            837584481526874153L,
-            831987774499454997L
-        )
-    }
-
     override suspend fun CommandEvent.execute() {
         val roles = jda.getRolesByName(args, true)
         val role = roles.firstOrNull { ROLES.contains(it.idLong) }


### PR DESCRIPTION
Remove the ROLES companion object in RoleCommand, so that the Bump Notification role is assignable as well