### PR TITLE
fix(role-suggestions): make role suggestions case-insensitive

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "me.bristermitten"
-version = "1.1.0"
+version = "1.1.1"
 
 
 repositories {

--- a/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
@@ -1,7 +1,8 @@
 package me.bristermitten.devdenbot.util
 
+import info.debatty.java.stringsimilarity.SorensenDice
 import org.apache.commons.text.similarity.LevenshteinDistance
-import info.debatty.java.stringsimilarity.*;
+import java.util.*
 
 val levenshtein = LevenshteinDistance.getDefaultInstance()::apply
 
@@ -14,7 +15,7 @@ fun getSuggestion(
     allowedValues: List<String>,
     threshold: Double = SUGGESTION_THRESHOLD,
 ): String? = allowedValues
-        .map { it to similarity(input, it) }
+        .map { it to similarity(input.toLowerCase(Locale.ROOT), it.toLowerCase(Locale.ROOT)) }
         .maxByOrNull { (_, distance) -> distance }
         ?.takeIf { (_, distance) -> distance >= threshold}
         ?.first

--- a/src/test/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtilsTest.kt
+++ b/src/test/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtilsTest.kt
@@ -25,6 +25,15 @@ internal class StringSimilarityUtilsTest {
     }
 
     @Test
+    fun `test getSuggestion returns case insensitive suggestion`() {
+        val input = "cLASH OF cODY"
+        val allowedValues = testRoles
+        val suggestion = getSuggestion(input, allowedValues)
+        assertNotNull(suggestion)
+        assertEquals("Clash of Code", suggestion)
+    }
+
+    @Test
     fun `test getSuggestion none match returns null`() {
         val input = "someInput"
         val allowedValues = testRoles


### PR DESCRIPTION
Transform all roles to lower case before comparing with (lowercase) role names.

I did not bother to add any performance improvements because of simplicity and clarity which should be completely fine since the number of roles is very small.