### PR TITLE
fix: send error message when role is called without arguments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "me.bristermitten"
-version = "1.1.1"
+version = "1.1.2"
 
 
 repositories {

--- a/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
@@ -17,6 +17,10 @@ class RoleCommand @Inject constructor(
 ) {
 
     override suspend fun CommandEvent.execute() {
+        if (args == ""){
+            channel.sendMessage("Invalid use of the role command: Please specify a role.")
+            return
+        }
         val roles = jda.getRolesByName(args, true)
         val role = roles.firstOrNull { ROLES.contains(it.idLong) }
         if (role == null) {

--- a/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
@@ -19,11 +19,6 @@ class RoleCommand @Inject constructor(
     override suspend fun CommandEvent.execute() {
         val roles = jda.getRolesByName(args, true)
         val role = roles.firstOrNull { ROLES.contains(it.idLong) }
-
-        if (role == null && args.length <= 2){
-            channel.sendMessage("Invalid role!")
-            return
-        }
         if (role == null) {
             val suggestion = getSuggestion(
                 args,

--- a/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/commands/roles/RoleCommand.kt
@@ -19,6 +19,11 @@ class RoleCommand @Inject constructor(
     override suspend fun CommandEvent.execute() {
         val roles = jda.getRolesByName(args, true)
         val role = roles.firstOrNull { ROLES.contains(it.idLong) }
+
+        if (role == null && args.length <= 2){
+            channel.sendMessage("Invalid role!")
+            return
+        }
         if (role == null) {
             val suggestion = getSuggestion(
                 args,

--- a/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
@@ -15,11 +15,10 @@ fun getSuggestion(
     allowedValues: List<String>,
     threshold: Double = SUGGESTION_THRESHOLD,
 ): String? {
-
     if (input.length <= 2){
         return null;
     }
-
+    
     return allowedValues
         .map { it to similarity(input.toLowerCase(Locale.ROOT), it.toLowerCase(Locale.ROOT)) }
         .maxByOrNull { (_, distance) -> distance }

--- a/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
@@ -14,8 +14,15 @@ fun getSuggestion(
     input: String,
     allowedValues: List<String>,
     threshold: Double = SUGGESTION_THRESHOLD,
-): String? = allowedValues
+): String? {
+
+    if (input.length <= 2){
+        return null;
+    }
+
+    return allowedValues
         .map { it to similarity(input.toLowerCase(Locale.ROOT), it.toLowerCase(Locale.ROOT)) }
         .maxByOrNull { (_, distance) -> distance }
         ?.takeIf { (_, distance) -> distance >= threshold}
         ?.first
+}

--- a/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/util/StringSimilarityUtils.kt
@@ -8,18 +8,20 @@ val levenshtein = LevenshteinDistance.getDefaultInstance()::apply
 
 private const val SUGGESTION_THRESHOLD = .25
 
-private val similarity = SorensenDice(2)::similarity
+private const val k = 2 // number of letters that form a comparison group in the SD similarity algorithm
+private val similarity = SorensenDice(k)::similarity
 
 fun getSuggestion(
     input: String,
     allowedValues: List<String>,
     threshold: Double = SUGGESTION_THRESHOLD,
 ): String? {
-    if (input.length <= 2){
+    if (input.length <= k){
         return null;
     }
-    
+
     return allowedValues
+        .filter{ it.length >= k }
         .map { it to similarity(input.toLowerCase(Locale.ROOT), it.toLowerCase(Locale.ROOT)) }
         .maxByOrNull { (_, distance) -> distance }
         ?.takeIf { (_, distance) -> distance >= threshold}


### PR DESCRIPTION
The similarity function cannot handle strings with length < k = 2, so an additional check is required for that.

Now, calling the getSuggestion method with an argument whose length is < 2 characters will no longer lead to an exception but instead simply send the "Invalid Role" message. Roles with a length < 2 will no longer be considered in the role suggestion (previously, an error would be throw there)

Bonus: If no arguments are given, the bot will reply with the following message:
`Invalid use of the role command: Please specify a role.`