### PR TITLE
fix: xp calculation on message deletion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "me.bristermitten"
-version = "1.1.4"
+version = "1.1.5"
 
 
 repositories {

--- a/src/main/kotlin/me/bristermitten/devdenbot/xp/XPMessageListener.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/xp/XPMessageListener.kt
@@ -92,7 +92,6 @@ class XPMessageListener @Inject constructor(private val config: DDBConfig) : Eve
 
     private suspend fun onGuildMessageDelete(event: GuildMessageDeleteEvent) {
         val message = MessageCache.getCached(event.messageIdLong) ?: return
-        val contents = stripMessage(message.msg)
 
         val user = StatsUsers[message.authorId]
         val author = event.jda.retrieveUserById(message.authorId).await() ?: return
@@ -100,7 +99,7 @@ class XPMessageListener @Inject constructor(private val config: DDBConfig) : Eve
         if (!shouldCountForStats(author, message.msg, event.channel, config)) {
             return
         }
-        val gained = xpForMessage(contents).roundToInt()
+        val gained = xpForMessage(message.msg).roundToInt()
 
         user.giveXP((-gained).toBigInteger())
         logger.info {


### PR DESCRIPTION
previously, the following message would not be given the same amount of xp on deletion that was added before:
`<a<b1>3> rest of the message`

That's because the message was stripped of pings twice (only) on message deletion, so the <a<b1>> was falsely identified as a ping and removed. The message cache only contains stripped messages, so stripping it again will lead to xp differences between the deleted xp and the previously added xp.

This PR aims towards fixing this minor issue.