### PR TITLE
Slight adjustments to XP formula

### DIFF
--- a/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
@@ -56,7 +56,7 @@ fun xpForMessage(message: String): Double {
     val compressibility = compressibility(message)
     val wordiness = wordiness(message)
     val length = message.length.toDouble()
-    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 20.0) * length.pow(0.7)
+    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 25.0) * length.pow(0.7)
 }
 
 fun xpForLevel(level: Int): BigInteger = level.toBigDecimal()

--- a/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
@@ -56,7 +56,7 @@ fun xpForMessage(message: String): Double {
     val compressibility = compressibility(message)
     val wordiness = wordiness(message)
     val length = message.length.toDouble()
-    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 25.0) * length.pow(0.73)
+    return ((1 - compressibility) * (0.5 + 0.5 * wordiness)) * tanh(length / 25.0) * length.pow(0.73)
 }
 
 fun xpForLevel(level: Int): BigInteger = level.toBigDecimal()

--- a/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
@@ -56,7 +56,7 @@ fun xpForMessage(message: String): Double {
     val compressibility = compressibility(message)
     val wordiness = wordiness(message)
     val length = message.length.toDouble()
-    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 25.0) * length.pow(0.75)
+    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 25.0) * length.pow(0.73)
 }
 
 fun xpForLevel(level: Int): BigInteger = level.toBigDecimal()

--- a/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/xp/ExperienceCalculations.kt
@@ -56,7 +56,7 @@ fun xpForMessage(message: String): Double {
     val compressibility = compressibility(message)
     val wordiness = wordiness(message)
     val length = message.length.toDouble()
-    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 25.0) * length.pow(0.7)
+    return ((1 - compressibility) * 0.7 + wordiness * 0.2) * tanh(length / 25.0) * length.pow(0.75)
 }
 
 fun xpForLevel(level: Int): BigInteger = level.toBigDecimal()


### PR DESCRIPTION
Adjusted tanh divisor to 25 instead of 20, and length exponent from .7 to .73. Without these adjustments, two short messages will give more XP than one longer one:

`sending two messages on the same line` = 9.4

`sending two messages` + `on different lines` = 10.2

With these adjustments, that will change:

`sending two messages on the same line` = 9.4

`sending two messages` + `on different lines` = 8.9

This will also make longer messages fall off in value a bit less as they get longer.

Before:
`Long message, probably an explanation of something pretty complicated` = 13.9

After: 
`Long message, probably an explanation of something pretty complicated` = 15.7