### PR TITLE
Performance: reduce username fetches

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "me.bristermitten"
-version = "1.2.0"
+version = "1.2.1"
 
 
 repositories {

--- a/src/main/kotlin/me/bristermitten/devdenbot/xp/commands/LeaderboardCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/xp/commands/LeaderboardCommand.kt
@@ -103,7 +103,7 @@ class LeaderboardCommand @Inject constructor(
             { builder, statsUser, index ->
                 builder.field(
                     "#${index + 1} - ${by(statsUser)} $leaderboardName",
-                    jda.retrieveUserById(statsUser.userId).await()?.asMention ?: "Unknown User (${statsUser.userId})",
+                    jda.retrieveUserById(statsUser.userId, false).await()?.asMention ?: "Unknown User (${statsUser.userId})",
                 )
             },
             entryCount = users.size,


### PR DESCRIPTION
Scrolling through the leaderboard is pretty slow at the moment because all users from a page are refetched when that page is displayed.

By changing the `update` argument to `false`, the bot will preferrably use the cached user instead of refetching it, which should improve performance dramatically. 