### PR TITLE
Hide admin commands behind -admin flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "me.bristermitten"
-version = "1.2.4"
+version = "1.3.0"
 
 
 repositories {

--- a/src/main/kotlin/me/bristermitten/devdenbot/commands/Preconditions.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/commands/Preconditions.kt
@@ -2,11 +2,12 @@ package me.bristermitten.devdenbot.commands
 
 import com.jagrosh.jdautilities.command.CommandEvent
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Member
 
 class PreconditionFailedException(val reason: String? = null) : Exception()
 
 fun CommandEvent.senderMustHaveRole(roleId: Long) {
-    if (member.isOwner || member.hasPermission(Permission.ADMINISTRATOR)) {
+    if (isAdmin(member)) {
         return
     }
 
@@ -15,3 +16,5 @@ fun CommandEvent.senderMustHaveRole(roleId: Long) {
         throw PreconditionFailedException("You must have the role `$roleName` to use this command!")
     }
 }
+
+fun isAdmin(member: Member) = member.isOwner || member.hasPermission(Permission.ADMINISTRATOR)

--- a/src/main/kotlin/me/bristermitten/devdenbot/commands/management/SetVarCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/commands/management/SetVarCommand.kt
@@ -32,9 +32,10 @@ class SetVarCommand @Inject constructor(
 ) {
 
     override suspend fun CommandEvent.execute() {
-        val args = arguments()
+        val arguments = arguments()
+        val args = arguments.args
 
-        args.validateLength(3) {
+        arguments.validateArgLength(3) {
             awaitReply("Not enough arguments.")
             return
         }

--- a/src/main/kotlin/me/bristermitten/devdenbot/extensions/Messages.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/extensions/Messages.kt
@@ -1,6 +1,7 @@
 package me.bristermitten.devdenbot.extensions
 
 import com.jagrosh.jdautilities.command.CommandEvent
+import java.util.*
 
 val WHITESPACE_REGEX = Regex("\\s+")
 
@@ -9,14 +10,14 @@ fun CommandEvent.arguments(): Arguments {
     val args = split.drop(1).map(::Argument)
     return Arguments(
         split.first() //This might break in future for prefixes that don't require a space. deal with it
-        , args)
+        , args.filter { !it.isFlag }, args.filter { it.isFlag })
 }
 
 
-class Arguments(val command: String, private val args: List<Argument>) : List<Argument> by args {
+class Arguments(val command: String, val args: List<Argument>, val flags: List<Argument>) {
 
-    inline fun validateLength(length: Int, orElse: () -> Unit) {
-        if (size < length)
+    inline fun validateArgLength(length: Int, orElse: () -> Unit) {
+        if (args.size < length)
             orElse()
     }
 
@@ -27,7 +28,9 @@ class Arguments(val command: String, private val args: List<Argument>) : List<Ar
 }
 
 
-class Argument(val content: String) {
+class Argument(unformattedContent: String) {
+    val isFlag: Boolean = unformattedContent.startsWith('-')
+    val content = unformattedContent.removePrefix("-")
 
     inline fun validate(predicate: (String) -> Boolean, orElse: () -> Unit) {
         if (predicate(content)) return
@@ -35,7 +38,7 @@ class Argument(val content: String) {
     }
 
     override fun equals(other: Any?) = if (other is String) content.equals(other, true) else content == other
-    override fun hashCode(): Int = content.hashCode()
+    override fun hashCode(): Int = content.toLowerCase(Locale.ROOT).hashCode()
 }
 
 

--- a/src/main/kotlin/me/bristermitten/devdenbot/extensions/commands/CommandEvent.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/extensions/commands/CommandEvent.kt
@@ -44,6 +44,7 @@ suspend fun CommandEvent.firstMentionedUser(): User? {
         return message.mentionedUsers.first()
     }
     return arguments()
+        .args
         .asSequence()
         .map(Argument::content)
         .mapNotNull(String::toLongOrNull)

--- a/src/main/kotlin/me/bristermitten/devdenbot/log/LogLevelCommand.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/log/LogLevelCommand.kt
@@ -21,7 +21,7 @@ class LogLevelCommand : DevDenCommand(
     override suspend fun CommandEvent.execute() {
         senderMustHaveRole(BOT_CONTRIBUTOR_ROLE_ID)
 
-        val levelName = arguments().first().content
+        val levelName = arguments().args.first().content
         val level = when (levelName.lowercase()) { // Fake enum :(
             "off" -> Level.OFF
             "error", "severe" -> Level.ERROR


### PR DESCRIPTION
Added flags to command parsing. Flags are arguments that start with a `-` and that are treated seperatly on command parsing

Made the ddhelp command only show ownerOnly commands when the -admin or the -owner flag is set. Executing the ddhelp command with either of these flags requires admin permissions.