### PR TITLE
Fix leaderboard order

### DIFF
--- a/src/main/kotlin/me/bristermitten/devdenbot/leaderboard/Leaderboard.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/leaderboard/Leaderboard.kt
@@ -12,7 +12,7 @@ open class Leaderboard<T> (private val comparator: Comparator<T>) {
 
     fun addAll(entries: Collection<T>) {
         entries.filter { !indices.contains(it) }.forEach { this.entries.add(it) }
-        this.entries.sortWith(comparator)
+        this.entries.sortWith(comparator.reversed())
         indices.clear()
         this.entries.forEachIndexed { i, it -> indices[it] = i }
     }

--- a/src/main/kotlin/me/bristermitten/devdenbot/leaderboard/Leaderboards.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/leaderboard/Leaderboards.kt
@@ -18,4 +18,4 @@ object Leaderboards {
 }
 
 class StatsUserLeaderboard<T : Comparable<T>>(val name: String, val keyExtractor: (StatsUser) -> T) :
-    Leaderboard<StatsUser>(Comparator.comparing(keyExtractor).reversed())
+    Leaderboard<StatsUser>(Comparator.comparing(keyExtractor))

--- a/src/test/kotlin/me/bristermitten/devdenbot/leaderboard/LeaderboardTest.kt
+++ b/src/test/kotlin/me/bristermitten/devdenbot/leaderboard/LeaderboardTest.kt
@@ -1,0 +1,34 @@
+package me.bristermitten.devdenbot.leaderboard
+
+import me.bristermitten.devdenbot.data.StatsUser
+import me.bristermitten.devdenbot.util.atomic
+import java.math.BigInteger
+import java.util.Comparator.comparing
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class LeaderboardTest {
+
+    private val users = (0..9).map { StatsUser(it.toLong(), xp = BigInteger("${50 - 2 * it}").atomic()) }
+
+
+    @Test
+    fun `Test addAll adds all entries correctly`() {
+        val leaderboard = Leaderboard<StatsUser>(comparing { it.xp })
+        leaderboard.addAll(users);
+
+        assertEquals(10, leaderboard.getEntryCount());
+        users.forEachIndexed { idx, user -> assertEquals(user, leaderboard.getEntry(idx)) }
+    }
+
+    @Test
+    fun `Test update adds entry correctly`() {
+        val leaderboard = Leaderboard<StatsUser>(comparing { it.xp })
+        leaderboard.addAll(users);
+
+        val newUser = StatsUser(4711, xp = BigInteger("47").atomic())
+        leaderboard.update(newUser)
+        assertEquals(11, leaderboard.getEntryCount())
+        assertEquals(newUser, leaderboard.getEntry(2))
+    }
+}


### PR DESCRIPTION
Opposed to what we thought earlier, there have never been duplicate entries in the leaderboard. Instead, the sorting order on `addAll` was correct, while the sorting order for update was reversed.

That way, whenever a user with high xp was updated, it would be moved to the bottom of the leaderboard - It appeared as if they were twice in the leaderboard, but instead, while scrolling to the last page, their score was updated, moving them to the bottom of the list.

This was found by adding basic unit tests for the leaderboard class.